### PR TITLE
Datetime convert to unixtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+.idea/

--- a/composer.json
+++ b/composer.json
@@ -48,5 +48,11 @@
         "PDPhilip\\Elasticsearch\\ElasticServiceProvider"
       ]
     }
+  },
+  "config": {
+    "allow-plugins": {
+      "php-http/discovery": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }


### PR DESCRIPTION
I have observed some problems, as always, with the dateTime issue.

At first, I thought it was a matter of my mapping, since I don't use the default, `"strict_date_optional_time||epoch_millis"` but `"epoch_second||yyyy-MM-dd HH:mm:ss"`. So, I reindexed my data locally to see if the problem persisted with the official mapping.

And yes, it persists. It has been clear to me for a long time that Elasticsearch, with its changes, sometimes complicates things a lot, and that the reality is that date queries are better done in Unix time format. Since version 6, which is the one I started working with, it has never given me any problems.

That forces me to always do the Unix time conversion myself, but with Carbo, that is not a big problem.

## Proof of concept

### Laravel
Before reviewing the package and trying to upload a PR with a possible solution, I performed some concept tests on my data from the last few days, which I have locally.

I did the two tests on the two mappings. The one I use and the one with the official format dateTime.

For testing, I used the model with its connections, clearing the caches just in case.

Then I ran the tests in the Kibana console of my installation (it is not the one for the package tests) and the result was the same.

I only get results using the unixtime equivalent of my query date in the query.

```php
// Works
$analyzers = WorkAnalyzer::orderBy('datetime', 'desc')->where('status_code', '200')->whereDate('datetime', '>=', '1710892800')->count();  // result 146501 docs
// Not working
// $analyzers = WorkAnalyzer::orderBy('datetime', 'desc')->where('status_code', '200')->where('datetime', '>=', '2024-03-20')->count();  // result 0
// $analyzers = WorkAnalyzer::orderBy('datetime', 'desc')->where('status_code', '200')->where('datetime', '2024-03-20')->count(); // result 0

// $analyzers = WorkAnalyzer::orderBy('datetime', 'desc')->where('status_code', '200')->whereDate('datetime', '>=', '2024-03-20')->count(); // result 0
```


## Kibana

```
GET /work-analyzers/_mapping/field/datetime
{
  "analyzers-2022111701": {
    "mappings": {
      "datetime": {
        "full_name": "datetime",
        "mapping": {
          "datetime": {
            "type": "date",
            "format": "epoch_second||yyyy-MM-dd HH:mm:ss",
            "ignore_malformed": true
          }
        }
      }
    }
  }
}

GET /analyzers-2024032301/_mapping/field/datetime
{
  "analyzers-2024032301": {
    "mappings": {
      "datetime": {
        "full_name": "datetime",
        "mapping": {
          "datetime": {
            "type": "date",
            "ignore_malformed": true
          }
        }
      }
    }
  }
}
```

```json
// 1710892800 = 2024-03-20T00:00:00Z
GET /analyzers-2024032301/_count
{
    "query": {
        "bool": {
            "filter": [
                { "term":  { "status_code": "200" }},
                { "range": { "datetime": { "gte": "1710892800" }}}
            ]
        }
    }
}
{
  "count": 146501,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  }
}

GET /analyzers-2024032301/_count
{
    "query": {
        "bool": {
            "filter": [
                { "term":  { "status_code": "200" }},
                { "range": { "datetime": { "gte": "2024-03-20T00:00:00Z"}}}
            ]
        }
    }
}
{
  "count": 0,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  }
}
```
```json
GET /analyzers-2024032301/_count
{
    "query": {
        "bool": {
            "filter": [
                { "term":  { "status_code": "200" }},
                { "range": { "datetime": { "gte": "2024-03-20"}}}
            ]
        }
    }
}
{
  "count": 0,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  }
}
``` 

This question, very important for me, since I have hundreds of millions of documents in my indexes, and the importance of their data over time is very necessary, since it is about control of electrical consumption in municipalities, has led me for a long time to use timestamp. When everything worked, it stopped working, and the theme is always in the datetime field.

I looked for help on Elasticsearch, and etc., and in the end, I chose to always convert the queries to timestamp.

## Testing

I have tried to understand how your testing works, to create a file of tests related to this issue.

But it has been impossible for me.

I can't find how you load the docs, nor do I know the operation since when it tries to run a test within QueriesTest, it forces me to run the entire eloquent group. I imagine it's because of the load.

In my case, what I do is refresh the indices in each block of tests, which allows me to treat each test as individual. Maybe a little slower.

Also, many times, when running tests, I get different results. Sometimes some tests fail, sometimes not. And after running several tests, I need to rebuild composer with --no-cache to get the tests OK.

I feel quite useless, with this topic. But hey, I prefer to leave what is highlighted. In the tests that I do in my app, I have created a battery for whereDate and for Between (I didn't do anything here, but I wanted to check that the problem was the same. Either it passes Unix time or it fails).