### PR TITLE
Please consider these two changes

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -160,10 +160,14 @@ class Connection extends BaseConnection
         $hosts = config('database.connections.elasticsearch.hosts') ?? null;
         $username = config('database.connections.elasticsearch.username') ?? null;
         $pass = config('database.connections.elasticsearch.password') ?? null;
+        $apiKey = config('database.connections.elasticsearch.api_key') ?? null;
         $certPath = config('database.connections.elasticsearch.ssl_cert') ?? null;
         $cb = ClientBuilder::create()->setHosts($hosts);
         if ($username && $pass) {
             $cb->setBasicAuthentication($username, $pass)->build();
+        } elseif ($apiKey) {
+            // Local deployment can also access via APIKEY
+            $cb->setApiKey($apiKey)->build();
         }
         if ($certPath) {
             $cb->setCABundle($certPath);

--- a/src/DSL/Bridge.php
+++ b/src/DSL/Bridge.php
@@ -58,6 +58,16 @@ class Bridge
         ];
         try {
             $process = $this->client->search($params);
+
+            // rawSearch() seems to be the only way to perform date_histogram
+            // so please enhance this to sanitize aggregations as well.
+            if (! empty($process['aggregations'])) {
+                $meta['timed_out'] = $process['timed_out'];
+                $meta['total'] = $process['hits']['total']['value'] ?? 0;
+                $meta['max_score'] = $process['hits']['max_score'] ?? 0;
+
+                return $this->_return($process['aggregations'], $meta, $params, $this->_queryTag(__FUNCTION__));
+            }
             
             return $this->_sanitizeSearchResponse($process, $params, $this->_queryTag(__FUNCTION__));
         } catch (Exception $e) {


### PR DESCRIPTION
1. Elasticsearch local deployment might also access via APIKEY.
2. date_histogram is a very powerful aggregation function in Elasticsearch and rawSearch() seems the current only method to perform such a search without violating the norm of Eloquent ORM. So I suggest allowing rawSearch() to perform raw construct aggregations and get the values back.