### PR TITLE
feat(builder): add "get" document handeling

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -27,6 +27,7 @@ use RuntimeException;
  * @method Results aggregate(string $function, array $wheres, array $options, array $columns)
  * @method Results distinct(array $wheres, array $options, array $columns, bool $includeDocCount = false)
  * @method Results find(array $wheres, array $options, array $columns)
+ * @method Results getDocument(string $id)
  * @method Results save(array $data, string $refresh)
  * @method array insertBulk(array $data, bool $returnData = false, string|null $refresh = false)
  * @method Results multipleAggregate(array $functions, array $wheres, array $options, string $column)

--- a/src/Eloquent/Docs/ModelDocs.php
+++ b/src/Eloquent/Docs/ModelDocs.php
@@ -53,6 +53,8 @@ use PDPhilip\Elasticsearch\Query\Builder;
  * @method static $this whereRegex(string $column, string $regex)
  * @method static $this whereNestedObject(string $column, Callable $callback, string $scoreType = 'avg')
  * @method static $this whereNotNestedObject(string $column, Callable $callback, string $scoreType = 'avg')
+ * @method static $this documentOrNew(string $id)
+ * @method static $this documentOrFail(string $id)
  * @method static $this firstOrCreate(array $attributes, array $values = [])
  * @method static $this firstOrCreateWithoutRefresh(array $attributes, array $values = [])
  * @method static $this orderBy(string $column, string $direction = 'asc')

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -173,7 +173,36 @@ test('No Document', function () {
 test('Find Or Fail', function () {
     $this->expectException(ModelNotFoundException::class);
     Product::findOrFail('51c33d8981fec6813e00000a');
+});
 
+test('Document Or New', function () {
+    $product = Product::documentOrNew('51c33d8981fec6813e00000a');
+    expect($product->exists)->toBe(false)
+        ->and($product['_id'])->toBe('51c33d8981fec6813e00000a');
+
+    $product['name'] = 'John Doe';
+    $product['description'] = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus lacinia odio vitae vestibulum vestibulum.';
+    $product['in_stock'] = 35;
+    $product->save();
+
+    $getDocument = Product::documentOrNew('51c33d8981fec6813e00000a');
+    expect($getDocument->exists)->toBe(true)->and($product['_id'])->toBe('51c33d8981fec6813e00000a');
+});
+
+test('Document Or Fail', function () {
+    $this->expectException(ModelNotFoundException::class);
+    Product::documentOrFail('51c33d8981fec6813e00000a');
+});
+
+test('Document Or Fail (Found)', function () {
+    $product = new Product;
+    $product['name'] = 'John Doe';
+    $product['description'] = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus lacinia odio vitae vestibulum vestibulum.';
+    $product['in_stock'] = 24;
+    $product['_id'] = '51c33d8981fec6813e00000a';
+    $product->save();
+    $getDocument = Product::documentOrFail('51c33d8981fec6813e00000a');
+    expect($getDocument->exists)->toBe(true)->and($product['_id'])->toBe('51c33d8981fec6813e00000a');
 });
 
 test('Create', function () {


### PR DESCRIPTION
**Purpose of this Pull Request**

This pull request adds a "get" implementation to the models.

**Reference**

- [Getting Documents in Elasticsearch PHP API](https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/getting-started-php.html#_getting_documents)

**Description**

Since "get" is a reserved term in Eloquent, I've named the method `document` instead. This PR introduces two new methods to all models:

- `documentOrNew`
- `documentOrFail`

Both methods accept an `id` as their only parameter and directly utilize the Elasticsearch `get` method to retrieve a document. The `documentOrFail` method will throw an exception if the document is not found, whereas `documentOrNew` will return a new instance of the model with the `id` set to the one you attempted to retrieve.

**Justification**

I often store documents directly and know the exact `id` values. While `findOrNew` exists, these new methods have less overhead since they do not perform a search for the document; they directly retrieve it using Elasticsearch's `get` method.
