### PR TITLE
feat(elasticsearch): enhance raw search functionality

### DIFF
--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -212,7 +212,29 @@ class Builder extends BaseEloquentBuilder
         return $model;
     }
 
-    /**
+  /**
+   * Performs a raw search using the provided body parameters.
+   *
+   * @param array $bodyParams The body parameters to use for the search.
+   * @param bool  $returnRaw  Specifies whether to return the raw search data or not.
+   *                          Defaults to false.
+   *
+   * @return ElasticCollection The search results as an ElasticCollection object.
+   */
+  public function rawSearch(array $bodyParams, bool $returnRaw = false): ElasticCollection
+  {
+    $data = $this->query->rawSearch($bodyParams, $returnRaw);
+    $results = $this->model->hydrate($data->data)->all();
+    $meta = $data->getMetaData();
+
+    $elasticCollection = $this->getModel()->newCollection($results);
+    $elasticCollection->setQueryMeta($meta);
+
+    return $elasticCollection;
+  }
+
+
+  /**
      * Hydrate the models from the given array.
      */
     public function hydrate(array $items): ElasticCollection

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -63,6 +63,7 @@ class Builder extends BaseEloquentBuilder
         //ES only:
         'matrix',
         'query',
+        'rawdsl',
         'rawsearch',
         'rawaggregation',
         'getindexsettings',
@@ -212,29 +213,25 @@ class Builder extends BaseEloquentBuilder
         return $model;
     }
 
-  /**
-   * Performs a raw search using the provided body parameters.
-   *
-   * @param array $bodyParams The body parameters to use for the search.
-   * @param bool  $returnRaw  Specifies whether to return the raw search data or not.
-   *                          Defaults to false.
-   *
-   * @return ElasticCollection The search results as an ElasticCollection object.
-   */
-  public function rawSearch(array $bodyParams, bool $returnRaw = false): ElasticCollection
-  {
-    $data = $this->query->rawSearch($bodyParams, $returnRaw);
-    $results = $this->model->hydrate($data->data)->all();
-    $meta = $data->getMetaData();
+    /**
+     * Performs a raw search using the provided body parameters.
+     *
+     * @param  array  $bodyParams  The body parameters to use for the search.
+     * @return ElasticCollection The search results as an ElasticCollection object.
+     */
+    public function rawSearch(array $bodyParams): ElasticCollection
+    {
+        $data = $this->query->rawSearch($bodyParams);
+        $results = $this->model->hydrate($data->data)->all();
+        $meta = $data->getMetaData();
 
-    $elasticCollection = $this->getModel()->newCollection($results);
-    $elasticCollection->setQueryMeta($meta);
+        $elasticCollection = $this->getModel()->newCollection($results);
+        $elasticCollection->setQueryMeta($meta);
 
-    return $elasticCollection;
-  }
+        return $elasticCollection;
+    }
 
-
-  /**
+    /**
      * Hydrate the models from the given array.
      */
     public function hydrate(array $items): ElasticCollection

--- a/src/Eloquent/Docs/ModelDocs.php
+++ b/src/Eloquent/Docs/ModelDocs.php
@@ -84,7 +84,8 @@ use PDPhilip\Elasticsearch\Query\Builder;
  * @method static ElasticCollection insert($values, $returnData = null):
  * @method static ElasticCollection insertWithoutRefresh($values, $returnData = null)
  * @method static array toDsl(array $columns = ['*'])
- * @method static ElasticCollection rawSearch(array $bodyParams, bool $returnRaw = false)
+ * @method static mixed rawDsl(array $bodyParams)
+ * @method static ElasticCollection rawSearch(array $bodyParams)
  * @method static array rawAggregation(array $bodyParams)
  * @method static bool chunk(mixed $count, callable $callback, string $keepAlive = '5m')
  * @method static bool chunkById(mixed $count, callable $callback, $column = '_id', $alias = null, $keepAlive = '5m')

--- a/src/Eloquent/Docs/ModelDocs.php
+++ b/src/Eloquent/Docs/ModelDocs.php
@@ -84,7 +84,7 @@ use PDPhilip\Elasticsearch\Query\Builder;
  * @method static ElasticCollection insert($values, $returnData = null):
  * @method static ElasticCollection insertWithoutRefresh($values, $returnData = null)
  * @method static array toDsl(array $columns = ['*'])
- * @method static array rawSearch(array $bodyParams, bool $returnRaw = false)
+ * @method static ElasticCollection rawSearch(array $bodyParams, bool $returnRaw = false)
  * @method static array rawAggregation(array $bodyParams)
  * @method static bool chunk(mixed $count, callable $callback, string $keepAlive = '5m')
  * @method static bool chunkById(mixed $count, callable $callback, $column = '_id', $alias = null, $keepAlive = '5m')

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -40,6 +40,8 @@ class Builder extends BaseBuilder
 
     public array $cursor = [];
 
+    public array $randomScore = [];
+
     public mixed $previousSearchAfter = null;
 
     public string $searchQuery = '';
@@ -959,6 +961,19 @@ class Builder extends BaseBuilder
         return $this;
     }
 
+    /**
+     * @return $this
+     */
+    public function orderByRandom($column, int $seed = 1): static
+    {
+        $this->randomScore = [
+            'column' => $column,
+            'seed' => $seed,
+        ];
+
+        return $this;
+    }
+
     //Filters
 
     public function groupBy(...$groups): Builder
@@ -1414,6 +1429,12 @@ class Builder extends BaseBuilder
         }
         if ($this->highlights) {
             $options['highlights'] = $this->highlights;
+        }
+        if ($this->fields) {
+            $options['fields'] = $this->fields;
+        }
+        if ($this->randomScore) {
+            $options['random_score'] = $this->randomScore;
         }
 
         return $options;

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -369,12 +369,9 @@ class Builder extends BaseBuilder
         return $this->_processDelete();
     }
 
-    public function rawSearch(array $bodyParams, $returnRaw = false): Collection
+    public function rawSearch(array $bodyParams, $returnRaw = false): Results
     {
-        $find = $this->connection->searchRaw($bodyParams, $returnRaw);
-        $data = $find->data;
-
-        return new Collection($data);
+      return $this->connection->searchRaw($bodyParams, $returnRaw);
     }
 
     public function rawAggregation(array $bodyParams): Collection

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1430,9 +1430,6 @@ class Builder extends BaseBuilder
         if ($this->highlights) {
             $options['highlights'] = $this->highlights;
         }
-        if ($this->fields) {
-            $options['fields'] = $this->fields;
-        }
         if ($this->randomScore) {
             $options['random_score'] = $this->randomScore;
         }

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -369,9 +369,16 @@ class Builder extends BaseBuilder
         return $this->_processDelete();
     }
 
-    public function rawSearch(array $bodyParams, $returnRaw = false): Results
+    public function rawDsl(array $bodyParams): mixed
     {
-      return $this->connection->searchRaw($bodyParams, $returnRaw);
+        $find = $this->connection->searchRaw($bodyParams, true);
+
+        return $find->data;
+    }
+
+    public function rawSearch(array $bodyParams): Results
+    {
+        return $this->connection->searchRaw($bodyParams, false);
     }
 
     public function rawAggregation(array $bodyParams): Collection

--- a/tests/Eloquent/ElasticsearchSpecificTest.php
+++ b/tests/Eloquent/ElasticsearchSpecificTest.php
@@ -2,7 +2,8 @@
 
 declare(strict_types=1);
 
-use Workbench\App\Models\Product;
+  use PDPhilip\Elasticsearch\Collection\ElasticCollection;
+  use Workbench\App\Models\Product;
 
 test('filter products within a geo box', function () {
 
@@ -65,7 +66,9 @@ test('search for products using regex on color', function () {
 });
 
 test('execute raw DSL query on products', function () {
-    Product::factory()->state(['color' => 'silver'])->create();
+  Product::factory()->state(['color' => 'silver'])->create();
+  Product::factory(2)->state(['color' => 'silver'])->create();
+  Product::factory(1)->state(['color' => 'blue'])->create();
 
     $bodyParams = [
         'query' => [
@@ -75,7 +78,12 @@ test('execute raw DSL query on products', function () {
         ],
     ];
     $products = Product::rawSearch($bodyParams);
-    expect($products)->toHaveCount(1);
+
+    expect($products)
+      ->toBeInstanceOf(ElasticCollection::class)
+      ->toHaveCount(2)
+      ->and($products->first())->toBeInstanceOf(Product::class)
+      ->and($products->first()['color'])->toBe('silver');
 });
 
 test('perform raw aggregation query', function () {


### PR DESCRIPTION
This commit makes a raw search return a collection of models instead of a raw array inside of a collection. It piggybacks on the hydrate method after a query is executed.

This will also give the flexibility to get random documents using a raw query that returns as Models.

- Updated `rawSearch` method in `ModelDocs` to return `ElasticCollection` instead of an array.
- Introduced detailed PHPDoc for `rawSearch` in `Builder` for better maintainability.
- Simplified `rawSearch` logic in `Query\Builder` to directly return search results.
- Enhanced tests to verify `ElasticCollection` integration and data consistency.

Closes #37 