### PR TITLE
Refract/connection

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -8,6 +8,7 @@ use Elastic\Elasticsearch\Client;
 use Elastic\Elasticsearch\ClientBuilder;
 use Elastic\Elasticsearch\Exception\AuthenticationException;
 use Illuminate\Database\Connection as BaseConnection;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use PDPhilip\Elasticsearch\DSL\Bridge;
 use PDPhilip\Elasticsearch\DSL\Results;
@@ -289,6 +290,7 @@ class Connection extends BaseConnection
                 'api_id' => null,
                 'index_prefix' => null,
                 'options' => [
+                    'logging' => false,
                     'allow_id_sort' => false,
                     'ssl_verification' => true,
                     'retires' => null,
@@ -375,25 +377,29 @@ class Connection extends BaseConnection
      */
     protected function _builderOptions(ClientBuilder $cb): ClientBuilder
     {
-        $cb->setSSLVerification($this->sslVerification);
+        $cb = $cb->setSSLVerification($this->sslVerification);
         if (isset($this->elasticMetaHeader)) {
-            $cb->setElasticMetaHeader($this->elasticMetaHeader);
+            $cb = $cb->setElasticMetaHeader($this->elasticMetaHeader);
         }
 
         if (isset($this->retires)) {
-            $cb->setRetries($this->retires);
+            $cb = $cb->setRetries($this->retires);
+        }
+
+        if ($this->config['options']['logging']) {
+            $cb = $cb->setLogger(Log::getLogger());
         }
 
         if ($this->config['ssl_cert']) {
-            $cb->setCABundle($this->config['ssl_cert']);
+            $cb = $cb->setCABundle($this->config['ssl_cert']);
         }
 
         if ($this->config['ssl']['cert']) {
-            $cb->setSSLCert($this->config['ssl']['cert'], $this->config['ssl']['cert_password']);
+            $cb = $cb->setSSLCert($this->config['ssl']['cert'], $this->config['ssl']['cert_password']);
         }
 
         if ($this->config['ssl']['key']) {
-            $cb->setSSLKey($this->config['ssl']['key'], $this->config['ssl']['key_password']);
+            $cb = $cb->setSSLKey($this->config['ssl']['key'], $this->config['ssl']['key_password']);
         }
 
         return $cb;

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -288,20 +288,20 @@ class Connection extends BaseConnection
                 'api_key' => null,
                 'api_id' => null,
                 'index_prefix' => null,
-                'ssl_cert' => null,
                 'options' => [
-                    'allow_id_sort' => null,
-                    'ssl_verification' => null,
+                    'allow_id_sort' => false,
+                    'ssl_verification' => true,
                     'retires' => null,
-                    'error_log_index' => null,
                     'meta_header' => null,
                 ],
+                'ssl_cert' => null,
                 'ssl' => [
                     'key' => null,
-                    'password' => null,
+                    'key_password' => null,
                     'cert' => null,
                     'cert_password' => null,
                 ],
+                'error_log_index' => false,
             ],
             $this->config
         );

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Illuminate\Support\Facades\DB;
 use PDPhilip\Elasticsearch\Connection;
 use PDPhilip\Elasticsearch\Schema\Builder as SchemaBuilder;
+use Elastic\Elasticsearch\Client;
 
 test('Connection', function () {
     $connection = DB::connection('elasticsearch');
@@ -23,6 +24,50 @@ test('Reconnect', function () {
     DB::purge('elasticsearch');
     $c2 = DB::connection('elasticsearch');
     expect(spl_object_hash($c1) !== spl_object_hash($c2))->toBeTrue();
+});
+
+test('Disconnect And Create New Connection', function () {
+  $connection = DB::connection('elasticsearch');
+  expect($connection)->toBeInstanceOf(Connection::class);
+  $client = $connection->getClient();
+  expect($client)->toBeInstanceOf(Client::class);
+
+  $connection->disconnect();
+  $client = $connection->getClient();
+  $this->assertNull($client);
+  DB::purge('elasticsearch');
+
+  $connection = DB::connection('elasticsearch');
+  expect($connection)->toBeInstanceOf(Connection::class);
+  $client = $connection->getClient();
+  expect($client)->toBeInstanceOf(Client::class);
+
+});
+
+test('DB', function () {
+  $connection = DB::connection('elasticsearch');
+  $this->assertInstanceOf(Client::class, $connection->getClient());
+});
+
+test('Connection Without auth_type', function () {
+  $this->expectException(RuntimeException::class);
+  $this->expectExceptionMessage('Invalid [auth_type] in database config. Must be: http or cloud');
+
+  new Connection(['name' => 'test']);
+});
+
+test('Cloud Connection Without cloud_id', function () {
+  $this->expectException(RuntimeException::class);
+  $this->expectExceptionMessage('auth_type of `cloud` requires `cloud_id` to be set');
+
+  new Connection(['name' => 'test', 'auth_type' => 'cloud']);
+});
+
+test('Http Connection Without hosts', function () {
+  $this->expectException(RuntimeException::class);
+  $this->expectExceptionMessage('auth_type of `http` requires `hosts` to be set');
+
+  new Connection(['name' => 'test', 'auth_type' => 'http']);
 });
 
 test('Schema Builder', function () {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -45,6 +45,9 @@ class TestCase extends Orchestra
             'driver' => 'elasticsearch',
             'auth_type' => 'http',
             'hosts' => ['http://localhost:9200'],
+            'options' => [
+              'logging' => true
+            ]
         ]);
     }
 }


### PR DESCRIPTION
This PR aims to refractor the current connection. It removes the dependencies on using config as that causes collisions when using multiple elastic connections. Instead, it uses the config that's passed to the connection by elastic.

I also added sanitization and validation of the connection to guarantee all connection values are set when creating the connection.

Finally, it adds a new option "logging" which enables the built-in elastic search logger but passes in and uses the current Laravel log instance based on the user's stack.
https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/enabling_logger.html