### PR TITLE
refactor: update the return type of getConnection()

### DIFF
--- a/src/Eloquent/Docs/ModelDocs.php
+++ b/src/Eloquent/Docs/ModelDocs.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Cursor;
 use PDPhilip\Elasticsearch\Collection\ElasticCollection;
+use PDPhilip\Elasticsearch\Connection;
 use PDPhilip\Elasticsearch\Eloquent\Model;
 use PDPhilip\Elasticsearch\Pagination\SearchAfterPaginator;
 use PDPhilip\Elasticsearch\Query\Builder;
@@ -93,7 +94,7 @@ use PDPhilip\Elasticsearch\Query\Builder;
  *
  * Index Methods ---------------------------------
  * @method static string getQualifiedKeyName()
- * @method static string getConnection()
+ * @method static Connection getConnection()
  * @method static void truncate()
  * @method static bool indexExists()
  * @method static bool deleteIndexIfExists()


### PR DESCRIPTION
 Using the package with phpstan I was getting an error when attempting to run this code 
 
 ```php
    public static function refreshIndex(): void
    {
        /** @var static $instance */
        $instance = new static();
        $index = $instance->getIndex();

        try {
            $client = $instance->getConnection()->getClient();
            $client?->indices()?->refresh(['index' => $index]);
        } catch (Throwable $th) {
            logger()->error('Failed to refresh index', ['index' => $index, 'error' => $th->getMessage()]);
        }
    } 
```

The error phpstan was throwing was 

```bash
 ------ ----------------------------------------------------------------------------------------------
  Line   app/Traits/Models/OnElasticsearchConnection.php (in context of class App\Models\Search\Lead)
 ------ ----------------------------------------------------------------------------------------------
  29     Cannot call method getClient() on string.
 ------ ----------------------------------------------------------------------------------------------
```

After digging it was found that the docblock in the `src/Eloquent/Docs/ModelDocs.php` is incorrectly claiming a string will be returned and not the correct return type of `use PDPhilip\Elasticsearch\Connection;`